### PR TITLE
Feature: resizable GUI

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -12,8 +12,8 @@
 #include "PluginEditor.h"
 
 //==============================================================================
-WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProcessor& p)
-    : AudioProcessorEditor (&p), processor (p)
+WaveNetVaComponent::WaveNetVaComponent (WaveNetVaAudioProcessor& p)
+    : processor (p)
 {
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to
@@ -124,14 +124,11 @@ WaveNetVaAudioProcessorEditor::WaveNetVaAudioProcessorEditor (WaveNetVaAudioProc
     ampMasterKnob.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 50, 20 );
     ampMasterKnob.setDoubleClickReturnValue(true, 0.5);
 
-    // Size of plugin GUI
-    setSize (1085, 540);
-
     processor.loadConfigAmp();
     resetImages();
 }
 
-WaveNetVaAudioProcessorEditor::~WaveNetVaAudioProcessorEditor()
+WaveNetVaComponent::~WaveNetVaComponent()
 {
     ampPresenceKnob.setLookAndFeel(nullptr);
     ampCleanBassKnob.setLookAndFeel(nullptr);
@@ -146,7 +143,7 @@ WaveNetVaAudioProcessorEditor::~WaveNetVaAudioProcessorEditor()
 }
 
 //==============================================================================
-void WaveNetVaAudioProcessorEditor::paint (Graphics& g)
+void WaveNetVaComponent::paint (Graphics& g)
 {
 
     // Workaround for graphics on Windows builds (clipping code doesn't work correctly on Windows)
@@ -160,7 +157,7 @@ void WaveNetVaAudioProcessorEditor::paint (Graphics& g)
 
 }
 
-void WaveNetVaAudioProcessorEditor::resized()
+void WaveNetVaComponent::resized()
 {
     // This is generally where you'll want to lay out the positions of any
     // subcomponents in your editor..
@@ -183,7 +180,7 @@ void WaveNetVaAudioProcessorEditor::resized()
     ampLED.setBounds(975, 40, 15, 25);
 }
 
-void WaveNetVaAudioProcessorEditor::buttonClicked(juce::Button* button)
+void WaveNetVaComponent::buttonClicked(juce::Button* button)
 {
     if (button == &ampOnButton) {
         ampOnButtonClicked();
@@ -192,7 +189,7 @@ void WaveNetVaAudioProcessorEditor::buttonClicked(juce::Button* button)
     }
 }
 
-void WaveNetVaAudioProcessorEditor::ampOnButtonClicked() {
+void WaveNetVaComponent::ampOnButtonClicked() {
     if (processor.amp_state == 0) {
         processor.amp_state = 1;
     }
@@ -202,7 +199,7 @@ void WaveNetVaAudioProcessorEditor::ampOnButtonClicked() {
     resetImages();
 }
 
-void WaveNetVaAudioProcessorEditor::ampCleanLeadButtonClicked() {
+void WaveNetVaComponent::ampCleanLeadButtonClicked() {
     if (processor.amp_lead == 1) {
         processor.amp_lead = 0;
         processor.loadConfigAmp();
@@ -217,7 +214,7 @@ void WaveNetVaAudioProcessorEditor::ampCleanLeadButtonClicked() {
     resetImages();
 }
 
-void WaveNetVaAudioProcessorEditor::sliderValueChanged(Slider* slider)
+void WaveNetVaComponent::sliderValueChanged(Slider* slider)
 {
     // Amp
 
@@ -238,7 +235,7 @@ void WaveNetVaAudioProcessorEditor::sliderValueChanged(Slider* slider)
 
 }
 
-void WaveNetVaAudioProcessorEditor::resetImages()
+void WaveNetVaComponent::resetImages()
 {
     if (processor.amp_state == 1 && processor.amp_lead == 1 ) {
         background_set = background_lead;
@@ -288,4 +285,32 @@ void WaveNetVaAudioProcessorEditor::resetImages()
             0.0);
     }
     repaint();
+}
+
+// Wrapper implementation
+WrappedWaveNetVaAudioProcessorEditor::WrappedWaveNetVaAudioProcessorEditor(WaveNetVaAudioProcessor& p)
+    : AudioProcessorEditor(p), waveNetVaComponent(p)
+{
+    addAndMakeVisible(waveNetVaComponent);
+
+    if (auto* constrainer = getConstrainer())
+    {
+        constrainer->setFixedAspectRatio(static_cast<double> (originalWidth) / static_cast<double> (originalHeight));
+        constrainer->setSizeLimits(originalWidth / 4, originalHeight / 4, originalWidth * 2, originalHeight * 2);
+    }
+
+    setResizable(true, true);
+    setSize(originalWidth, originalHeight);
+}
+
+void WrappedWaveNetVaAudioProcessorEditor::resized()
+{
+    const auto scaleFactor = static_cast<float> (getWidth()) / originalWidth;
+    waveNetVaComponent.setTransform(AffineTransform::scale(scaleFactor));
+    waveNetVaComponent.setBounds(0, 0, originalWidth, originalHeight);
+}
+
+void WrappedWaveNetVaAudioProcessorEditor::resetImages()
+{
+    waveNetVaComponent.resetImages();
 }

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -313,6 +313,7 @@ WrappedWaveNetVaAudioProcessorEditor::WrappedWaveNetVaAudioProcessorEditor(WaveN
     float scaledWidth = static_cast<float> (originalWidth) * waveNetVaComponent.getGuiScaleFactor();
     float scaledHeight = static_cast<float> (originalHeight) * waveNetVaComponent.getGuiScaleFactor();
     setSize(scaledWidth, scaledHeight);
+    resetImages();
 }
 
 void WrappedWaveNetVaAudioProcessorEditor::resized()

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -287,6 +287,16 @@ void WaveNetVaComponent::resetImages()
     repaint();
 }
 
+float WaveNetVaComponent::getGuiScaleFactor()
+{
+    return static_cast<float> (processor.gui_scale_factor);
+}
+
+void WaveNetVaComponent::persistGuiScaleFactor(float scaleFactor)
+{
+    processor.gui_scale_factor = static_cast<double> (scaleFactor);
+}
+
 // Wrapper implementation
 WrappedWaveNetVaAudioProcessorEditor::WrappedWaveNetVaAudioProcessorEditor(WaveNetVaAudioProcessor& p)
     : AudioProcessorEditor(p), waveNetVaComponent(p)
@@ -299,8 +309,10 @@ WrappedWaveNetVaAudioProcessorEditor::WrappedWaveNetVaAudioProcessorEditor(WaveN
         constrainer->setSizeLimits(originalWidth / 4, originalHeight / 4, originalWidth * 2, originalHeight * 2);
     }
 
-    setResizable(true, true);
-    setSize(originalWidth, originalHeight);
+    setResizable(true, true);    
+    float scaledWidth = static_cast<float> (originalWidth) * waveNetVaComponent.getGuiScaleFactor();
+    float scaledHeight = static_cast<float> (originalHeight) * waveNetVaComponent.getGuiScaleFactor();
+    setSize(scaledWidth, scaledHeight);
 }
 
 void WrappedWaveNetVaAudioProcessorEditor::resized()
@@ -308,6 +320,7 @@ void WrappedWaveNetVaAudioProcessorEditor::resized()
     const auto scaleFactor = static_cast<float> (getWidth()) / originalWidth;
     waveNetVaComponent.setTransform(AffineTransform::scale(scaleFactor));
     waveNetVaComponent.setBounds(0, 0, originalWidth, originalHeight);
+    waveNetVaComponent.persistGuiScaleFactor(scaleFactor);
 }
 
 void WrappedWaveNetVaAudioProcessorEditor::resetImages()

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -17,14 +17,14 @@
 //==============================================================================
 /**
 */
-class WaveNetVaAudioProcessorEditor  : public AudioProcessorEditor,
+class WaveNetVaComponent  : public Component,
                                        private Button::Listener,
                                        private Slider::Listener
                                 
 {
 public:
-    WaveNetVaAudioProcessorEditor (WaveNetVaAudioProcessor&);
-    ~WaveNetVaAudioProcessorEditor();
+    WaveNetVaComponent (WaveNetVaAudioProcessor&);
+    ~WaveNetVaComponent();
 
     //==============================================================================
     void paint (Graphics&) override;
@@ -84,5 +84,18 @@ public:
     std::unique_ptr <AudioProcessorValueTreeState::SliderAttachment> presenceSliderAttach;
     std::unique_ptr <AudioProcessorValueTreeState::SliderAttachment> masterSliderAttach;
  
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WaveNetVaAudioProcessorEditor)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WaveNetVaComponent)
+};
+
+class WrappedWaveNetVaAudioProcessorEditor : public AudioProcessorEditor
+{
+public:
+    WrappedWaveNetVaAudioProcessorEditor(WaveNetVaAudioProcessor&);
+    void resized() override;
+    void resetImages();
+private:
+    static constexpr int originalWidth { 1085 };
+    static constexpr int originalHeight { 540 };
+
+    WaveNetVaComponent waveNetVaComponent;
 };

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -31,6 +31,8 @@ public:
     void resized() override;
 
     void resetImages();
+    float getGuiScaleFactor();
+    void persistGuiScaleFactor(float scaleFactor);
 
 private:
     // This reference is provided as a quick way for your editor to

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -238,6 +238,7 @@ void WaveNetVaAudioProcessor::getStateInformation (MemoryBlock& destData)
     std::unique_ptr<XmlElement> xml (state.createXml());
     xml->setAttribute ("amp_state", amp_state);
     xml->setAttribute ("amp_lead", amp_lead);
+    xml->setAttribute ("gui_scale_factor", gui_scale_factor);
     copyXmlToBinary (*xml, destData);
 }
 
@@ -255,6 +256,7 @@ void WaveNetVaAudioProcessor::setStateInformation (const void* data, int sizeInB
             treeState.replaceState (juce::ValueTree::fromXml (*xmlState));
             amp_state = xmlState->getBoolAttribute ("amp_state");
             amp_lead = xmlState->getBoolAttribute ("amp_lead");
+            gui_scale_factor = xmlState->getDoubleAttribute ("gui_scale_factor", 1.0);
             if (auto* editor = dynamic_cast<WrappedWaveNetVaAudioProcessorEditor*> (getActiveEditor()))
                 editor->resetImages();
         }

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -225,7 +225,7 @@ bool WaveNetVaAudioProcessor::hasEditor() const
 
 AudioProcessorEditor* WaveNetVaAudioProcessor::createEditor()
 {
-    return new WaveNetVaAudioProcessorEditor (*this);
+    return new WrappedWaveNetVaAudioProcessorEditor (*this);
 }
 
 //==============================================================================
@@ -255,7 +255,7 @@ void WaveNetVaAudioProcessor::setStateInformation (const void* data, int sizeInB
             treeState.replaceState (juce::ValueTree::fromXml (*xmlState));
             amp_state = xmlState->getBoolAttribute ("amp_state");
             amp_lead = xmlState->getBoolAttribute ("amp_lead");
-            if (auto* editor = dynamic_cast<WaveNetVaAudioProcessorEditor*> (getActiveEditor()))
+            if (auto* editor = dynamic_cast<WrappedWaveNetVaAudioProcessorEditor*> (getActiveEditor()))
                 editor->resetImages();
         }
     }

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -91,6 +91,7 @@ public:
     int amp_state = 1; // 0 = off, 1 = on
     int amp_lead = 1; // 1 = clean, 0 = lead
     int custom_tone = 0; // 0 = custom tone loaded, 1 = default channel tone
+    double gui_scale_factor = 1.0;
     File loaded_tone;
     juce::String loaded_tone_name;
 


### PR DESCRIPTION
Resizable GUI for SmartAmp, as per feature request in: https://github.com/GuitarML/SmartGuitarAmp/issues/10

Example video:
![226760661-ab22de23-d94d-40d4-8b03-6513c0bf6c02](https://user-images.githubusercontent.com/2873991/226985782-8c8304db-0848-45fc-889f-d615ad119f2b.gif)

**What was done:**
- `WaveNetVaAudioProcessorEditor` was renamed to `WaveNetVaComponent` inheriting `Component` instead of `AudioProcessorEditor`
- `WrappedWaveNetVaAudioProcessorEditor` was introduced, which inherits `AudioProcessorEditor` and wraps `WaveNetVaComponent` 
- Resizing the window scales the wrapped `WaveNetVaComponent` accordingly. Layout code remains the same.
- The scale factor is persisted in `gui_scale_factor` alongside `amp_state` and `amp_lead` in `AudioProcessorValueTreeState`. This allows multiple windows to be sized differently.

This process was explained in detail in the tutorial at https://www.youtube.com/watch?v=0hh1-D3gLKw (repository: https://github.com/Thrifleganger/resizable-plugin-window-demo). The persistence of `gui_scale_factor` differs from the tutorial, where system-wide `ApplicationProperties` was used instead.

Open for discussion - I'm new to JUCE and C++ is not my main language.